### PR TITLE
Removed default tunnel identifier

### DIFF
--- a/tasks/sauce_connect.js
+++ b/tasks/sauce_connect.js
@@ -93,7 +93,6 @@ module.exports = function (grunt) {
 
 	grunt.registerMultiTask('sauce_connect', 'Grunt plug-in to download and launch Sauce Labs Sauce Connect', function () {
 		var options = this.options({
-				tunnelIdentifier: 'Tunnel' + new Date().getTime(),
 				verbose: grunt.option('verbose') === true,
 				logger: grunt.verbose.writeln
 			}),


### PR DESCRIPTION
On my setup, passing identifier to tunnel caused fake domain not found. Maybe i should do something extra to pair my test runner with connect, but it sound like advanced option which could be optional.
